### PR TITLE
Added User-Agent header and code to dynamically generate new Sec-WebSocket-Key and verify Sec-WebSocket-Accept

### DIFF
--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -5,6 +5,11 @@
             "help": "Whether to use Mbed HTTP - if disabled, it will remove any code related to Mbed HTTP",
             "value": true,
             "macro_name": "MBED_WS_HAS_MBED_HTTP"
+        },
+        "user-agent": {
+            "help": "User-Agent header presented to server",
+            "value": "Mbed-WS-Client",
+            "macro_name": "MBED_WS_USER_AGENT"
         }
     }
 }

--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -8,7 +8,7 @@
         },
         "user-agent": {
             "help": "User-Agent header presented to server",
-            "value": "Mbed-WS-Client",
+            "value": "\"Mbed-WS-Client\"",
             "macro_name": "MBED_WS_USER_AGENT"
         }
     }

--- a/source/ws_client.h
+++ b/source/ws_client.h
@@ -69,7 +69,12 @@ protected:
         if (r != NSAPI_ERROR_OK) {
             return r;
         }
-        return socket->connect(host, port);
+
+        SocketAddress sockAddr;
+        _network->gethostbyname(host, &sockAddr);
+        sockAddr.set_port(port);
+
+        return socket->connect(sockAddr);
     }
 };
 

--- a/source/ws_client_base.h
+++ b/source/ws_client_base.h
@@ -228,7 +228,7 @@ public:
         mbedtls_base64_encode( (unsigned char *)&ws_sec_accept, sizeof(ws_sec_accept), &key_len, ws_sec_accept_hash, 20);
 
 #ifdef MBED_WS_DEBUG
-        printf("Calculated Sec-Websocket-Accpet: %s\n", ws_sec_accept);
+        printf("Calculated Sec-WebSocket-Accept: %s\n", ws_sec_accept);
         printf("Headers:\n");
 #endif
         for (size_t ix = 0; ix < res->get_headers_length(); ix++) {

--- a/source/wss_client.h
+++ b/source/wss_client.h
@@ -64,7 +64,12 @@ protected:
         if (r != NSAPI_ERROR_OK) {
             return r;
         }
-        return socket->connect(host, port);
+
+        SocketAddress sockAddr;
+        _network->gethostbyname(host, &sockAddr);
+        sockAddr.set_port(port);
+
+        return socket->connect(sockAddr);
     }
 
 private:


### PR DESCRIPTION
Per discussion on [StackOverflow](https://stackoverflow.com/questions/18265128/what-is-sec-websocket-key-for), Sec-WebSocket-Key better be random and different for each new connection, that is how Sec-WebSocket-Key is implemented in mainstream WS client such as lws. 

Also added is User-Agent header. It is customary and can also be useful to report this to server.

Hope these two features will make this library one step closer to be production ready.